### PR TITLE
Fixed login screen not being able to scroll fully when WebView height is not taller than the card

### DIFF
--- a/src/scripture-forge/src/home/home.web-view.tsx
+++ b/src/scripture-forge/src/home/home.web-view.tsx
@@ -178,7 +178,7 @@ globalThis.webViewComponent = function ScriptureForgeHome({
   if (isLoginBusy) logInOrOutButtonContents = <Spinner className="tw-h-4 tw-w-4" />;
 
   return !isLoggedIn ? (
-    <div className="tw-flex tw-bg-muted/50 tw-h-screen tw-items-center tw-justify-center">
+    <div className="tw-flex tw-bg-muted/50 tw-min-h-screen tw-p-2 tw-items-center tw-justify-center">
       <Card className="tw-max-w-md">
         <CardHeader>
           <CardTitle>{localizedStrings['%scriptureForge_login_page_title%']}</CardTitle>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/369e820e-3fa7-4a47-b235-621176db49d8)

After:

![image](https://github.com/user-attachments/assets/76d0406b-fb2c-4e09-8ec6-afeea5a5a337)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/scripture-forge-platform-extensions/7)
<!-- Reviewable:end -->
